### PR TITLE
[FEATURE] Erweitere Text zur Git-Konfiguration um eine Zeile

### DIFF
--- a/git/git-cheatsheet-de.md
+++ b/git/git-cheatsheet-de.md
@@ -40,6 +40,7 @@ git config --global user.email "jane.doe@example.com"
 ### Sachen zum Copy'n'Pasten
 
 ```bash
+git config --global init.defaultBranch main
 git config --global core.autocrlf false
 git config --global core.eol lf
 git config --global branch.autoSetupMerge always


### PR DESCRIPTION
In erster Zeile, weil der Befehl  direkt den main-branch erzeugt