### PR TITLE
[BUGFIX] Link zu oliverklee.de-Homepage fixen

### DIFF
--- a/git/git-cheatsheet-de.md
+++ b/git/git-cheatsheet-de.md
@@ -209,8 +209,9 @@ Der Body einer Commit-Message sollte das Warum eines Commits beschreiben
 Je nach Projekt oder Organisation können im Subject Codes für die Art der
 Änderung stehen.
 
-Bei Projekten von [oliverklee.de](oliverklee.de) verwenden wir beispielsweise
-die folgenden Codes (angelehnt an die Konventionen des TYPO3-Core):
+Bei Projekten von [oliverklee.de](https://www.oliverklee.de/) verwenden wir
+beispielsweise die folgenden Codes (angelehnt an die Konventionen des
+TYPO3-Core):
 
 - `[FEATURE]` (plus GitHub-Label **enhancement**): wenn neue Funktionalität
   hinzugefügt wird


### PR DESCRIPTION
Links zu Websites müssen immer auch das Protokoll enthalten, damit sie funktionieren.